### PR TITLE
FIX: stack items paginations

### DIFF
--- a/issuu-panel.php
+++ b/issuu-panel.php
@@ -3,7 +3,7 @@
 Plugin Name: Issuu Panel
 Plugin URI: https://github.com/issuu/issuu-panel
 Description: Admin panel for Issuu. You can upload your documents, create folders and embed documents in posts.
-Version: 2.1.0
+Version: 2.1.1
 Author: Pedro Marcelo and Issuu
 Author URI: https://issuu.com
 License: GPL3
@@ -11,7 +11,7 @@ License: GPL3
 
 if (defined('ISSUU_PANEL_VERSION'))
 {
-	switch (version_compare(ISSUU_PANEL_VERSION, '2.1.0')) {
+	switch (version_compare(ISSUU_PANEL_VERSION, '2.1.1')) {
 		case -1:
 			wp_die("A lower version of Issuu Panel plugin is already installed");
 			break;
@@ -30,7 +30,7 @@ if (defined('ISSUU_PANEL_VERSION'))
 |--------------------------------------
 */
 
-define('ISSUU_PANEL_VERSION', '2.1.0');
+define('ISSUU_PANEL_VERSION', '2.1.1');
 define('ISSUU_PANEL_DIR', plugin_dir_path(__FILE__));
 define('ISSUU_PANEL_URL', plugin_dir_url(__FILE__));
 define('ISSUU_PANEL_PREFIX', 'issuu_painel_');

--- a/issuuservice-lib/lib/class.issuufolder.php
+++ b/issuuservice-lib/lib/class.issuufolder.php
@@ -88,18 +88,38 @@ class IssuuFolder extends IssuuServiceAPI
         {
             $result['stat'] = 'ok';
             $result['stack'] = $this->clearObjectJson($response_stack);
+            $has_next = true;
+            $page = 1;
 
-            // get stack items
-            $response_stack_items = $this->curlRequest(
-                $this->getApiUrl('/stacks/'.$stackId.'/items'),
-                array(
-                    'includeUnlisted' => 'true',
-                ),
-                $this->headers
-            );
-            $response_stack_items = json_decode($response_stack_items, true);
+            while($has_next) {
+                // get stack items
+                $response_stack_items = $this->curlRequest(
+                    $this->getApiUrl('/stacks/'.$stackId.'/items'),
+                    array(
+                        'includeUnlisted' => 'true',
+                        'page' => $page,
+                    ),
+                    $this->headers
+                );
+                $response_stack_items = json_decode($response_stack_items, true);
+                $cleared_object = $this->clearObjectJson($response_stack_items);
+
+                if(isset($cleared_object->links['next']))
+                {
+                    $page++;
+                }
+                else
+                {
+                    $has_next = false;
+                }
+
+
+                foreach($cleared_object->results as $item_id)
+                {
+                    $stack_items[] = $item_id;
+                }
+            }            
             
-            $stack_items = $this->clearObjectJson($response_stack_items)->results;
             // get data from each document
             foreach($stack_items as $item)
             {

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,9 @@ You can send the translation by e-mail. Send for indri@issuu.com
 
 == Changelog ==
 
+= 2.1.1 =
+* Updated: Improves for API usage
+
 = 2.1.0 =
 * Updated: show documents information inside folders
 


### PR DESCRIPTION
Fix for more than 10 documents per stack.

Example of the result:
<img width="865" alt="image" src="https://github.com/issuu/issuu-panel/assets/41742354/c57734b2-a124-41f3-a825-470061cea97a">